### PR TITLE
fix: 유저 위젯 정보 받아오기 API 에러

### DIFF
--- a/backend/src/main/java/com/example/demo/entity/User.java
+++ b/backend/src/main/java/com/example/demo/entity/User.java
@@ -5,6 +5,7 @@ import javax.persistence.*;
 @Entity
 public class User {
     @Id
+    @Column(name = "user_Id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/backend/src/main/java/com/example/demo/entity/UserWidget.java
+++ b/backend/src/main/java/com/example/demo/entity/UserWidget.java
@@ -5,15 +5,9 @@ import java.io.Serializable;
 
 @Entity
 public class UserWidget implements Serializable {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @JoinColumn(name = "user_id")
-    private Long userId;
-
-    @JoinColumn(name = "widget_id")
-    private Long widgetId;
+    @EmbeddedId
+    UserWidgetId userWidgetId;
 
     @Column(name = "x", nullable = false)
     private int x;
@@ -27,22 +21,19 @@ public class UserWidget implements Serializable {
     @Column(name = "h", nullable = false)
     private int h;
 
-    public Long getUserId() {
-        return userId;
+    public UserWidget(){};
+
+    public UserWidget(UserWidgetId userWidgetId){
+        this.userWidgetId = userWidgetId;
     }
 
-    public void setUserId(Long userId) {
-        this.userId = userId;
+    public Long getUserId(){
+        return userWidgetId.getUserId();
     }
 
-    public Long getWidgetId() {
-        return widgetId;
+    public Long getWidgetId(){
+        return userWidgetId.getWidgetId();
     }
-
-    public void setWidgetId(Long widgetId) {
-        this.widgetId = widgetId;
-    }
-
     public int getX() {
         return x;
     }

--- a/backend/src/main/java/com/example/demo/entity/UserWidgetId.java
+++ b/backend/src/main/java/com/example/demo/entity/UserWidgetId.java
@@ -1,0 +1,32 @@
+package com.example.demo.entity;
+
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+@Embeddable
+public class UserWidgetId implements Serializable {
+    private Long userId;
+    private Long widgetId;
+
+    public UserWidgetId(){}
+    public UserWidgetId(Long userId, Long widgetId){
+        this.userId = userId;
+        this.widgetId = widgetId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getWidgetId() {
+        return widgetId;
+    }
+
+    public void setWidgetId(Long widgetId) {
+        this.widgetId = widgetId;
+    }
+}

--- a/backend/src/main/java/com/example/demo/entity/Widget.java
+++ b/backend/src/main/java/com/example/demo/entity/Widget.java
@@ -6,6 +6,7 @@ import javax.persistence.*;
 public class Widget {
 
     @Id
+    @Column(name = "widget_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/backend/src/main/java/com/example/demo/repository/UserWidgetRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/UserWidgetRepository.java
@@ -1,11 +1,12 @@
 package com.example.demo.repository;
 import com.example.demo.entity.UserWidget;
+import com.example.demo.entity.UserWidgetId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserWidgetRepository extends JpaRepository<UserWidget, Long> {
+public interface UserWidgetRepository extends JpaRepository<UserWidget, UserWidgetId> {
     UserWidget save(UserWidget userEntity);
 
     @Query(value = "SELECT * FROM USER_WIDGET WHERE USER_ID = ?1", nativeQuery = true)

--- a/backend/src/main/java/com/example/demo/repository/WidgetRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/WidgetRepository.java
@@ -15,6 +15,6 @@ public interface WidgetRepository extends JpaRepository<Widget, Long> {
     @Query(value = "SELECT * FROM WIDGET WHERE NAME = ?1", nativeQuery = true)
     Widget findByName(String name);
 
-    @Query(value = "SELECT * FROM WIDGET WHERE ID = ?1", nativeQuery = true)
+    @Query(value = "SELECT * FROM WIDGET WHERE WIDGET_ID = ?1", nativeQuery = true)
     Widget findByWidgetId(Long id);
 }

--- a/backend/src/main/java/com/example/demo/service/DemoService.java
+++ b/backend/src/main/java/com/example/demo/service/DemoService.java
@@ -4,6 +4,7 @@ import com.example.demo.dto.UserDto;
 import com.example.demo.dto.UserWidgetDto;
 import com.example.demo.entity.User;
 import com.example.demo.entity.UserWidget;
+import com.example.demo.entity.UserWidgetId;
 import com.example.demo.entity.Widget;
 import com.example.demo.repository.UserRepository;
 import com.example.demo.repository.UserWidgetRepository;
@@ -71,9 +72,8 @@ public class DemoService {
             Widget findExistWidget = widgetRepository.findByName(userWidgetDto.getName());
             if (findExistWidget == null)
                 System.out.println(responseService.errorResponse(400, "widget not found").log);
-            UserWidget userWidget = new UserWidget();
-            userWidget.setUserId(findExistUser.getId());
-            userWidget.setWidgetId(findExistWidget.getId());
+            UserWidgetId userWidgetId= new UserWidgetId(findExistUser.getId(), findExistWidget.getId());
+            UserWidget userWidget = new UserWidget(userWidgetId);
             userWidget.setX(userWidgetDto.getX());
             userWidget.setY(userWidgetDto.getY());
             userWidget.setW(userWidgetDto.getW());

--- a/backend/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/backend/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -12,88 +12,96 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DemoApplicationTests {
 
-	@Autowired
-	private DemoService demoService;
-	@Autowired
-	private WidgetRepository widgetRepository;
-	@Test
-	void 로그인테스트() {
-		//given
-		UserDto userDto = new UserDto();
-		userDto.setEmail("krkr@gmail.com");
-		userDto.setPassword("1234");
+    @Autowired
+    private DemoService demoService;
+    @Autowired
+    private WidgetRepository widgetRepository;
 
-		//when
-		System.out.println(demoService.login(userDto).log);
+    @Test
+    void 로그인테스트() {
+        //given
+        UserDto userDto = new UserDto();
+        userDto.setEmail("krkr@gmail.com");
+        userDto.setPassword("1234");
 
-		//than
-	}
+        //when
+        System.out.println(demoService.login(userDto).log);
 
-	@Test
-	void 회원가입테스트(String email){
-		//given
-		UserDto userDto = new UserDto();
-		userDto.setEmail(email);
-		userDto.setPassword("1234");
+        //than
+    }
 
-		//when
+    @Test
+    void 회원가입테스트(String email) {
+        //given
+        UserDto userDto = new UserDto();
+        userDto.setEmail(email);
+        userDto.setPassword("1234");
 
-		System.out.println(demoService.signup(userDto).log);
-		//than
-		로그인테스트();
-	}
+        //when
 
-	@Test
-	void 위젯추가테스트(String widgetName){
-		//given
-		Widget widget = new Widget();
+        System.out.println(demoService.signup(userDto).log);
+        //than
+        로그인테스트();
+    }
+
+    @Test
+    void 위젯추가테스트(String widgetName) {
+        //given
+        Widget widget = new Widget();
         widget.setName(widgetName);
         Widget widget1 = widgetRepository.save(widget);
-		if (widget1 == null)
-			System.out.println("null");
-		else
-			System.out.println("Widget Add OK");
-		//when
+        if (widget1 == null)
+            System.out.println("null");
+        else
+            System.out.println("Widget Add OK");
+        //when
 
-		//than
-	}
+        //than
+    }
 
-	@Test
-	void 유저위젯패치테스트(){
-		회원가입테스트("krkr@gmail.com");
-		위젯추가테스트("widget1");
-		위젯추가테스트("widget2");
-		//given
-		UserWidgetDto[] userWidgetDtos = new UserWidgetDto[2];
-		UserWidgetDto userWidgetDto = new UserWidgetDto();
-		userWidgetDto.setName("widget1");
-		userWidgetDto.setX(1);
-		userWidgetDto.setY(2);
-		userWidgetDto.setW(3);
-		userWidgetDto.setH(4);
-		userWidgetDtos[0] = userWidgetDto;
+    UserWidgetDto 유저위젯정보생성(String name, int x, int y, int w, int h) {
+        UserWidgetDto userWidgetDto = new UserWidgetDto();
+        userWidgetDto.setName(name);
+        userWidgetDto.setX(x);
+        userWidgetDto.setY(y);
+        userWidgetDto.setW(w);
+        userWidgetDto.setH(h);
+        return userWidgetDto;
+    }
 
-		UserWidgetDto userWidgetDto2 = new UserWidgetDto();
-		userWidgetDto2.setName("widget2");
-		userWidgetDto2.setX(5);
-		userWidgetDto2.setY(6);
-		userWidgetDto2.setW(7);
-		userWidgetDto2.setH(8);
-		userWidgetDtos[1] = userWidgetDto2;
+    @Test
+    void 유저위젯패치테스트() {
+        회원가입테스트("krkr@gmail.com");
+        위젯추가테스트("widget1");
+        위젯추가테스트("widget2");
+        위젯추가테스트("widget3");
+        //given
+        UserWidgetDto[] userWidgetDtos = new UserWidgetDto[3];
+        userWidgetDtos[0] = 유저위젯정보생성("widget1", 1, 1, 1, 1);
+        userWidgetDtos[1] = 유저위젯정보생성("widget2", 2, 2, 2, 2);
+        userWidgetDtos[2] = 유저위젯정보생성("widget3", 3, 3, 3, 3);
 
-		demoService.patchUserWidget("krkr@gmail.com", userWidgetDtos);
-		//when
 
-		//than
-	}
+        demoService.patchUserWidget("krkr@gmail.com", userWidgetDtos);
 
-	@Test
-	void 유저위젯받아오기테스트(){
-		유저위젯패치테스트();
+        userWidgetDtos[0] = 유저위젯정보생성("widget1", 999, 1, 1, 1);
+        userWidgetDtos[1] = 유저위젯정보생성("widget2", 2, 2, 2, 2);
+        userWidgetDtos[2] = 유저위젯정보생성("widget3", 3, 3, 3, 3);
 
-		UserWidgetDto[] userWidgetDtos = demoService.getUserWidget("krkr@gmail.com");
-		for (UserWidgetDto x: userWidgetDtos) {
-			System.out.println(x.getName());
-		}
-	}
+        demoService.patchUserWidget("krkr@gmail.com", userWidgetDtos);
+        //when
+
+        //than
+    }
+
+    @Test
+    void 유저위젯받아오기테스트() {
+        유저위젯패치테스트();
+
+        UserWidgetDto[] userWidgetDtos = demoService.getUserWidget("krkr@gmail.com").dataList;
+        for (UserWidgetDto x: userWidgetDtos) {
+            System.out.println(x.getName() + " " + x.getX());
+        }
+
+    }
 }


### PR DESCRIPTION
- patchUserWidget 서비스 함수 이용하여 동일한 name의 widget 목록을 업데이트 할 시 업데이트가 아니라 추가가 되는 에러 수정
  - patchUserWidget 함수에서 userWidgetRepository.save() 함수 이용하여 DB에 Entity 저장 시 Primary Key의 정보를 인식하지 못하여 업데이트가 아닌 추가가 되는 문제가 발생.
  - Entity(userWidget)에 @Embeddable 어노테이션을 이용하여 Composite Primary Key를 구현하였고, Repository에서 Primary Key의 정보를 인식할 수 있도록 수정함.