### PR TITLE
feat: market API - widget목록 가져오기, widget 등록

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/MarketController.java
+++ b/backend/src/main/java/com/example/demo/controller/MarketController.java
@@ -1,0 +1,32 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.WidgetDto;
+import com.example.demo.response.CommonResponse;
+import com.example.demo.response.ListResponse;
+import com.example.demo.response.ResponseService;
+import com.example.demo.service.MarketService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/market")
+public class MarketController {
+    @Autowired
+    MarketService marketService;
+
+    @Autowired
+    ResponseService responseService;
+
+    @GetMapping("")
+    public ListResponse<WidgetDto[]> getMarketWidget(){
+        return marketService.getMarketWidget();
+    }
+
+    @PostMapping("")
+    public CommonResponse addMarketWidget(@RequestBody() WidgetDto widgetDto){
+        if (widgetDto == null || widgetDto.getName().equals(""))
+            return responseService.errorResponse(400, "Invalid data");
+        return marketService.addMarketWidget(widgetDto);
+    }
+}

--- a/backend/src/main/java/com/example/demo/controller/UserController.java
+++ b/backend/src/main/java/com/example/demo/controller/UserController.java
@@ -2,22 +2,19 @@ package com.example.demo.controller;
 
 import com.example.demo.dto.UserWidgetDto;
 import com.example.demo.dto.WidgetDto;
-import com.example.demo.entity.Widget;
 import com.example.demo.response.CommonResponse;
 import com.example.demo.response.ListResponse;
 import com.example.demo.response.ResponseService;
-import com.example.demo.service.DemoService;
+import com.example.demo.service.UserService;
 import com.example.demo.dto.UserDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/user")
-public class DemoController {
+public class UserController {
     @Autowired
-    DemoService demoService;
+    UserService userService;
 
     @Autowired
     ResponseService responseService;
@@ -31,7 +28,7 @@ public class DemoController {
         if (userDto.getPassword() == null || userDto.getPassword().equals(""))
             return (responseService.errorResponse(400, "password null"));
 
-        return (demoService.signup(userDto));
+        return (userService.signup(userDto));
     }
 
     //로그인
@@ -43,25 +40,25 @@ public class DemoController {
         if (userDto.getPassword() == null || userDto.getPassword().equals(""))
             return (responseService.errorResponse(400, "password null"));
 
-        return (demoService.login(userDto));
+        return (userService.login(userDto));
     }
 
     //GET 위젯 정보
     @GetMapping("/{email}/widgets")
     public ListResponse<UserWidgetDto[]> getUserWidget(@PathVariable String email) {
-        return (demoService.getUserWidget(email));
+        return (userService.getUserWidget(email));
     }
 
     //PATCH 위젯 정보
     @PatchMapping("/{email}/widgets")
     public CommonResponse patchUserWidget(@PathVariable() String email, @RequestBody() UserWidgetDto[] userWidgetDtos) {
 
-        return (demoService.patchUserWidget(email, userWidgetDtos));
+        return (userService.patchUserWidget(email, userWidgetDtos));
     }
 
     //POST 위젯 정보
     @PostMapping("/widgets")
     public CommonResponse PostWidget(@RequestBody() WidgetDto[] widgetDtos) {
-        return (demoService.postWidget(widgetDtos));
+        return (userService.postWidget(widgetDtos));
     }
 }

--- a/backend/src/main/java/com/example/demo/repository/WidgetRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/WidgetRepository.java
@@ -5,13 +5,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface WidgetRepository extends JpaRepository<Widget, Long> {
-
+    List<Widget> findAll();
 
     Widget save(Widget widget);
+
     @Query(value = "SELECT * FROM WIDGET WHERE NAME = ?1", nativeQuery = true)
     Widget findByName(String name);
 

--- a/backend/src/main/java/com/example/demo/service/MarketService.java
+++ b/backend/src/main/java/com/example/demo/service/MarketService.java
@@ -1,0 +1,46 @@
+package com.example.demo.service;
+
+import com.example.demo.dto.WidgetDto;
+import com.example.demo.entity.Widget;
+import com.example.demo.repository.WidgetRepository;
+import com.example.demo.response.CommonResponse;
+import com.example.demo.response.ListResponse;
+import com.example.demo.response.ResponseService;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class MarketService {
+    private WidgetRepository widgetRepository;
+    private ResponseService responseService;
+
+    public MarketService(WidgetRepository widgetRepository,
+                         ResponseService responseService) {
+        this.responseService = responseService;
+        this.widgetRepository = widgetRepository;
+    }
+
+
+    public ListResponse<WidgetDto[]> getMarketWidget() {
+        List<Widget> widgets = widgetRepository.findAll();
+        WidgetDto[] widgetDtos = new WidgetDto[widgets.size()];
+        for (int i = 0; i < widgets.size(); ++i) {
+            WidgetDto widgetDto = new WidgetDto();
+            widgetDto.setName(widgets.get(i).getName());
+            widgetDtos[i] = widgetDto;
+        }
+        return responseService.getListResponse(widgetDtos);
+    }
+
+    public CommonResponse addMarketWidget(WidgetDto widgetDto) {
+        Widget findExistWidget = widgetRepository.findByName(widgetDto.getName());
+        if (findExistWidget != null)
+            return responseService.errorResponse(400, "Widget is Exist");
+        Widget widget = new Widget();
+        widget.setName(widgetDto.getName());
+        widgetRepository.save(widget);
+        return responseService.getCommonResponse();
+    }
+}

--- a/backend/src/main/java/com/example/demo/service/UserService.java
+++ b/backend/src/main/java/com/example/demo/service/UserService.java
@@ -16,20 +16,17 @@ import com.example.demo.response.ResponseService;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import java.util.Vector;
 
 @Transactional
 @Service
-public class DemoService {
+public class UserService {
     private UserRepository userRepository;
     private ResponseService responseService;
     private WidgetRepository widgetRepository;
     private UserWidgetRepository userWidgetRepository;
 
-    public DemoService(UserRepository userRepository,
+    public UserService(UserRepository userRepository,
                        ResponseService responseService,
                        WidgetRepository widgetRepository,
                        UserWidgetRepository userWidgetRepository) {

--- a/backend/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/backend/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -5,7 +5,10 @@ import com.example.demo.dto.UserWidgetDto;
 import com.example.demo.dto.WidgetDto;
 import com.example.demo.entity.Widget;
 import com.example.demo.repository.WidgetRepository;
-import com.example.demo.service.DemoService;
+import com.example.demo.response.CommonResponse;
+import com.example.demo.response.ListResponse;
+import com.example.demo.service.MarketService;
+import com.example.demo.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,9 +17,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 class DemoApplicationTests {
 
     @Autowired
-    private DemoService demoService;
+    private UserService userService;
     @Autowired
     private WidgetRepository widgetRepository;
+
+    @Autowired
+    private MarketService marketService;
 
     @Test
     void 로그인테스트() {
@@ -26,7 +32,7 @@ class DemoApplicationTests {
         userDto.setPassword("1234");
 
         //when
-        System.out.println(demoService.login(userDto).log);
+        System.out.println(userService.login(userDto).log);
 
         //than
     }
@@ -40,7 +46,7 @@ class DemoApplicationTests {
 
         //when
 
-        System.out.println(demoService.signup(userDto).log);
+        System.out.println(userService.signup(userDto).log);
         //than
         로그인테스트();
     }
@@ -83,13 +89,13 @@ class DemoApplicationTests {
         userWidgetDtos[2] = 유저위젯정보생성("widget3", 3, 3, 3, 3);
 
 
-        demoService.patchUserWidget("krkr@gmail.com", userWidgetDtos);
+        userService.patchUserWidget("krkr@gmail.com", userWidgetDtos);
 
         userWidgetDtos[0] = 유저위젯정보생성("widget1", 999, 1, 1, 1);
         userWidgetDtos[1] = 유저위젯정보생성("widget2", 2, 2, 2, 2);
         userWidgetDtos[2] = 유저위젯정보생성("widget3", 3, 3, 3, 3);
 
-        demoService.patchUserWidget("krkr@gmail.com", userWidgetDtos);
+        userService.patchUserWidget("krkr@gmail.com", userWidgetDtos);
         //when
 
         //than
@@ -99,7 +105,7 @@ class DemoApplicationTests {
     void 유저위젯받아오기테스트() {
         유저위젯패치테스트();
 
-        UserWidgetDto[] userWidgetDtos = demoService.getUserWidget("krkr@gmail.com").dataList;
+        UserWidgetDto[] userWidgetDtos = userService.getUserWidget("krkr@gmail.com").dataList;
         for (UserWidgetDto x: userWidgetDtos) {
             System.out.println(x.getName() + " " + x.getX());
         }
@@ -112,12 +118,34 @@ class DemoApplicationTests {
         wigetTest[0] = 위젯정보생성("test1");
         wigetTest[1] = 위젯정보생성("test2");
         wigetTest[2] = 위젯정보생성("test3");
-        demoService.postWidget(wigetTest);
+        userService.postWidget(wigetTest);
     }
 
     WidgetDto 위젯정보생성(String name) {
         WidgetDto widgetDto = new WidgetDto();
         widgetDto.setName(name);
         return widgetDto;
+    }
+
+    @Test
+    void 마켓위젯데이터추가(){
+        CommonResponse cm = marketService.addMarketWidget(위젯정보생성("widget1"));
+        System.out.println("마켓위젯데이터추가" + cm.log);
+    }
+
+    void 마켓위젯데이터추가(String widgetName){
+        CommonResponse cm = marketService.addMarketWidget(위젯정보생성(widgetName));
+        System.out.println("마켓위젯데이터추가" + widgetName + " " + cm.log);
+    }
+    @Test
+    void 마켓의위젯목록조회(){
+        마켓위젯데이터추가("widget1");
+        마켓위젯데이터추가("widget2");
+        마켓위젯데이터추가("widget3");
+        ListResponse<WidgetDto[]> cm = marketService.getMarketWidget();
+        System.out.println(cm.log);
+        for (WidgetDto widgetDto: cm.dataList) {
+            System.out.println(widgetDto.getName());
+        }
     }
 }


### PR DESCRIPTION
### PR 상세
- Service와 Controller 도메인별로 분리(User, Market)
- Market의 widget 목록 가져오는 API 구현 (getMarketWidget)
- Market에 새로운 widget 등록하는 API 구현 (addMarketWidget)

### 테스트 방법
API 요청을 통해 테스트

**GET /market 마켓의 위젯 목록 받아오기**
_request 데이터_
```
없음
```
_response 데이터_
```
{
        "status": "200",
        "log": "OK
	"datalist" : [
                 { 
		         "name": "widget1"
	         },
	         {
		         "name": "widget2"
	         }
        ] 
}
```

**POST /market 마켓에 위젯 추가하기.**
_request 데이터_
```
{ 
	"name": "widget1"
}
```
_response 데이터_
```
{
        status: "200",
        log": "OK"
}
```
- close #39 